### PR TITLE
Update ACMain.c

### DIFF
--- a/ACMain.c
+++ b/ACMain.c
@@ -500,6 +500,10 @@ void __attribute__ ((__interrupt__,auto_psv)) _ADCInterrupt(void) {
 			temperatureMultiplier = 8;	// Allow full throttle.
 		}
 		IqRefRef = __builtin_mulss(throttle,temperatureMultiplier) >> 3;
+		if (RPS_times16 < 8) {  // if less than 0.5 rev per second, make sure there's no regen.
+			if (IqRefRef < 0) IqRefRef = 0;
+		}
+
 		IdRefRef = IqRefRef;
 		if (IdRefRef < 0) IdRefRef = -IdRefRef;
 	}


### PR DESCRIPTION
Added a couple lines so that if the mechanical revolutions per second is less than 0.5, then there would be no regen allowed.  When driving down the street, you don't want to come to a stop, and then suddenly have the motor reverse direction, making you fly into reverse, because of the "regen".  LOL.  I mean, it's not regen at that point anyway.  It's just motor reversal of direction.
